### PR TITLE
ルートタスクを削除した場合は、タスク一覧画面に戻れるようにする

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -16,8 +16,12 @@ class TasksController < ApplicationController
 
   def destroy
     @task = Task.find(params[:id])
-    @task.destroy
-    redirect_back(fallback_location: tasks_path)
+
+    if @task.root? && @task.destroy
+      redirect_to tasks_path
+    else
+      redirect_back(fallback_location: tasks_path)
+    end
   end
 
   def update

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -12,4 +12,8 @@ class Task < ApplicationRecord
 
   validates :title, presence: true
   validates :status, presence: true
+
+  def root?
+    parent_task_id.nil?
+  end
 end


### PR DESCRIPTION
ルートタスクを削除したあとに、タスク詳細画面へ遷移しようとしてしまい、例外が発生するので修正します。