### PR TITLE
ルートタスク名にhoverしたときにリンクだとわかるようにする

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -94,6 +94,11 @@ a {
   color: #d6d6d6;
 }
 
+.task-link:hover {
+  cursor: pointer;
+  text-decoration: underline;
+}
+
 input {
   background-color: #242424;
   color: #d0d0d0;


### PR DESCRIPTION
<img width="297" alt="image" src="https://github.com/user-attachments/assets/6d3f4eeb-fc6f-44d5-bc89-ffd4a155447c" />

ポインタがどこにあるか分かりやすくします