### PR TITLE
タスク詳細のMarkdown出力機能を追加する

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -31,6 +31,13 @@ class TasksController < ApplicationController
     redirect_back(fallback_location: tasks_path)
   end
 
+  def export_markdown
+    root_task = Task.find(params[:id])
+    @markdown_content = root_task.to_markdown
+
+    send_data @markdown_content.encode("UTF-8"), filename: "tasks.md", type: "text/markdown; charset=UTF-8", disposition: "inline"
+  end
+
   private
 
   def task_params

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -16,4 +16,15 @@ class Task < ApplicationRecord
   def root?
     parent_task_id.nil?
   end
+
+  def to_markdown(indent_level = 0)
+    checkbox = status == "done" ? "[x]" : "[ ]"
+    markdown = "#{"  " * indent_level}- #{checkbox} #{title}\n"
+
+    sub_tasks.each do |child|
+      markdown += child.to_markdown(indent_level + 1)
+    end
+
+    markdown
+  end
 end

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -6,3 +6,5 @@
     <%= render_sub_task_tree(@parent_task) %>
   </li>
 </ol>
+
+<%= link_to "Markdownで出力", export_markdown_task_path, class: "btn btn-primary" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,10 @@ Rails.application.routes.draw do
   # root "posts#index"
 
   resources :tasks, only: [:index, :create, :show, :destroy, :update]
+
+  resources :tasks do
+    member do
+      get :export_markdown
+    end
+  end
 end


### PR DESCRIPTION
<img width="1194" alt="image" src="https://github.com/user-attachments/assets/160325a2-5608-4641-93f8-f6beb39a4d09" />

このようなタスク一覧があった場合に、Markdownで出力できる機能を追加します。

```md
- [ ] 新規開発を行う
  - [x] 要件定義を行う
    - [x] 要求を明確にする
  - [ ] 実装する
    - [ ] index画面を実装する
  - [ ] テストする
    - [ ] RSpecを書く
```

貼り付けたらこんな感じ

- [ ] 新規開発を行う
  - [x] 要件定義を行う
    - [x] 要求を明確にする
  - [ ] 実装する
    - [ ] index画面を実装する
  - [ ] テストする
    - [ ] RSpecを書く
